### PR TITLE
Remove sample image from microblog

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,18 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Microblog
+
+Short posts can be added to `src/content/microblog.json`. Each entry uses the following format:
+
+```
+{
+  "date": "YYYY-MM-DD",
+  "text": "Brief thought or commentary.",
+  "image": "/images/your-image.png" // optional
+}
+```
+
+Images referenced in the JSON should be placed in `public/images/`.
+

--- a/src/content/microblog.json
+++ b/src/content/microblog.json
@@ -1,0 +1,10 @@
+[
+  {
+    "date": "2025-06-10",
+    "text": "Today I read an article on diffusion models and their potential applications in image generation."
+  },
+  {
+    "date": "2025-06-11",
+    "text": "Explored the new React features; excited about server components!",
+  }
+]

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
 import './index.css';
 import Home from './pages/home/Home';
 import Chess from './pages/chess/Chess';
+import Microblog from './pages/microblog/Microblog';
 import MainLayout from './layouts/MainLayout';
 
 const router = createHashRouter([
@@ -20,6 +21,10 @@ const router = createHashRouter([
       {
         path: "/chess",
         element: <Chess />,
+      },
+      {
+        path: "/microblog",
+        element: <Microblog />,
       },
     ]
   }

--- a/src/layouts/Navbar.jsx
+++ b/src/layouts/Navbar.jsx
@@ -70,6 +70,13 @@ const Navbar = () => {
         >
           Chess
         </Button> */}
+        <Button
+          component={RouterLink}
+          to="/microblog"
+          style={linkStyle}
+        >
+          Microblog
+        </Button>
         <IconButton
           component="a"
           href="https://www.linkedin.com/in/edennagar/"

--- a/src/pages/microblog/Microblog.jsx
+++ b/src/pages/microblog/Microblog.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Container from '@mui/material/Container';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+import posts from '../../content/microblog.json';
+
+const Microblog = () => {
+  return (
+    <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+      {posts.map((post, index) => (
+        <Card key={index} sx={{ mb: 2, backgroundColor: '#222' }}>
+          <CardContent>
+            <Typography variant="body1" paragraph sx={{ color: 'white' }}>
+              {post.text}
+            </Typography>
+            {post.image && (
+              <Box
+                component="img"
+                src={post.image}
+                alt=""
+                sx={{ width: '100%', height: 'auto', mb: 1 }}
+              />
+            )}
+            <Typography variant="caption" sx={{ color: 'gray' }}>
+              {post.date}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Container>
+  );
+};
+
+export default Microblog;


### PR DESCRIPTION
## Summary
- remove example image from `public/images`
- update microblog posts to exclude image field
- tweak README example to use placeholder image path

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848929a40d483249e5b6df8524ac0db